### PR TITLE
Increase specificity

### DIFF
--- a/styles/red-wavy-underline.less
+++ b/styles/red-wavy-underline.less
@@ -4,6 +4,6 @@
   margin-top: 2px;
 }
 
-.spell-check-misspelling .region {
+.spell-check-misspelling .region.region {
   .red-wavy-underline;
 }


### PR DESCRIPTION
This PR increases specificity by adding an extra `.region` class.

I think your [recent change](https://github.com/lee-dohm/red-wavy-underline/commit/7c4ddd4f3d9578248c0fcee0b61735bb63f65698) didn't actually fix the specificity issue.

Because this package has now the same selector as the spell-check package (`.spell-check-misspelling .region` vs `.spell-check-misspelling .region`), the source order decides which styles to apply. It might work in your case, but in mine spell-check comes after red-wavy-underline:

![screen shot 2016-11-02 at 1 39 14 pm](https://cloud.githubusercontent.com/assets/378023/19918482/f73e8dc2-a10e-11e6-8ef4-75add2064940.png)
